### PR TITLE
Fix broken SIL OFL URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sketchize is free to use.
 
 ## License
 
-- The Sketchize wireframing sheets are licensed under the [SIL OFL 1.1](http://scripts.sil.org/OFL/)
+- The Sketchize wireframing sheets are licensed under the [SIL OFL 1.1](http://scripts.sil.org/OFL)
 - Sketchize's code is licensed under the [MIT License](https://opensource.org/licenses/mit-license.html/)
 - The Sketchize documentation is licensed under the [CC BY 3.0 License](http://creativecommons.org/licenses/by/3.0/)
 


### PR DESCRIPTION
Just a minor fix but the SIL OFL url is broken in the Readme.